### PR TITLE
Docker Compose: Specify "platform" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can run a seeding manually via:
 
 ### Full stack
 
-To start the sever run `docker-compose up`
+To start the sever run `docker-compose up platform`
 
 ### Vue app only
 


### PR DESCRIPTION
When running `docker-compose up`, the `platform` container needs to be specified (otherwise `platform_mock` will also start and cause a port collision on `8080`).