### PR TITLE
Allow admins to edit any project

### DIFF
--- a/client/src/admin/Base.vue
+++ b/client/src/admin/Base.vue
@@ -10,6 +10,7 @@
 
 <style lang="scss">
   @import '../assets/scss/_colors.scss';
+  @import '../assets/scss/main.scss';
   @import '~bootstrap/dist/css/bootstrap.min.css';
 
   .navbar-branding {

--- a/client/src/admin/projects/Edit.vue
+++ b/client/src/admin/projects/Edit.vue
@@ -1,0 +1,36 @@
+<template>
+<div v-if="event.id && project.id">
+  <div class="center-grid">
+    <div class="center-grid__content">
+      <div class="text-center">
+        <img src="/static/img/CoolestProjectsLogo.ab863b6.png" class="logo">
+      </div>
+      <div class="error-message-warning">
+        You are an admin editing a live project
+      </div>
+      <h2>Edit Project "{{ project.name }}"</h2>
+      <project-form :event="event" :project="project"></project-form>
+    </div>
+  </div>
+</div>
+</template>;
+
+<script>
+  import FetchProjectMixin from '@/project/FetchProjectMixin';
+  import ProjectForm from '@/project/Form';
+
+  export default {
+    name: 'AdminProjectsEdit',
+    mixins: [FetchProjectMixin],
+    components: {
+      ProjectForm,
+    },
+  };
+</script>
+
+<style lang="scss">
+  .logo {
+    max-width: 180px;
+    margin: 20px;
+  }
+</style>

--- a/client/src/admin/projects/ExtraDetails.vue
+++ b/client/src/admin/projects/ExtraDetails.vue
@@ -5,7 +5,7 @@
         <div class="error-message-warning">
           You are an admin editing a live project
         </div>
-        <extra-details :eventSlug='this.event.slug' :projectId='project.id' :_event='this.event' :_project='project'></extra-details>
+        <extra-details :eventSlug='event.slug' :projectId='project.id' :_event='event' :_project='project'></extra-details>
       </div>
     </div>
   </div>

--- a/client/src/admin/projects/ExtraDetails.vue
+++ b/client/src/admin/projects/ExtraDetails.vue
@@ -1,0 +1,32 @@
+<template>
+  <div v-if="event.id && project.id">
+    <div class="center-grid">
+      <div class="center-grid__content">
+        <div class="error-message-warning">
+          You are an admin editing a live project
+        </div>
+        <extra-details :eventSlug='this.event.slug' :projectId='project.id' :_event='this.event' :_project='project'></extra-details>
+      </div>
+    </div>
+  </div>
+</template>;
+
+<script>
+  import FetchProjectMixin from '@/project/FetchProjectMixin';
+  import ExtraDetails from '@/project/ExtraDetails';
+
+  export default {
+    name: 'AdminProjectsExtraDetails',
+    mixins: [FetchProjectMixin],
+    components: {
+      ExtraDetails,
+    },
+  };
+</script>
+
+<style lang="scss">
+  .logo {
+    max-width: 180px;
+    margin: 20px;
+  }
+</style>

--- a/client/src/admin/projects/List.vue
+++ b/client/src/admin/projects/List.vue
@@ -23,6 +23,7 @@
         <a v-if="props.row.owner" slot="owner.email" slot-scope="props" :href="`mailto:${props.row.owner.email}`">{{ props.row.owner.email }}</a>
         <a v-if="props.row.supervisor" slot="supervisor.email" slot-scope="props" :href="`mailto:${props.row.supervisor.email}`">{{ props.row.supervisor.email }}</a>
         <router-link class="fa fa-eye" slot="view" slot-scope="props" :to="{ name: 'AdminProjectsView', params: { projectId: props.row.id, eventSlug, _project: props.row, _event: event } }"></router-link>
+        <router-link class="fa fa-pencil" slot="edit" slot-scope="props" :to="{ name: 'AdminProjectsEdit', params: { eventSlug, projectId: props.row.id, _event: event, _project: props.row } }"></router-link>
       </v-server-table>
     </div>
   </div>
@@ -49,6 +50,7 @@
           'owner.email',
           'supervisor.email',
           'view',
+          'edit',
         ],
         tableState: {},
         itemsPerPage: 50,
@@ -90,6 +92,7 @@
             'owner.email': 'Owner Email',
             'supervisor.email': 'Supervisor Email',
             view: '',
+            edit: '',
           },
           highlightMatches: true,
           orderBy: {

--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -174,3 +174,10 @@ textarea {
   color: #F5A544;
   font-size: 14px;
 }
+
+.error-message-warning {
+  background-color: #d0021b;
+  color: #fff;
+  font-size: 18px;
+  padding: 10px;
+}

--- a/client/src/project/ExtraDetails.vue
+++ b/client/src/project/ExtraDetails.vue
@@ -88,8 +88,9 @@
           eventAction: 'ExtraDetailsProvided',
           eventLabel: this.event.id,
         });
+        const isAdmin = this.$route.path.startsWith('/admin/');
         this.$router.push({
-          name: 'CreateProjectCompleted',
+          name: isAdmin ? 'AdminProjects' : 'CreateProjectCompleted',
           params: {
             eventSlug: this.eventSlug,
             projectId: this.projectId,

--- a/client/src/project/Form.vue
+++ b/client/src/project/Form.vue
@@ -425,8 +425,9 @@
           }
           window.removeEventListener('beforeunload', this.onBeforeUnload);
           this.submitted = true;
+          const nextRouteNamePrefix = this.$route.path.startsWith('/admin/') ? 'Admin' : '';
           this.$router.push({
-            name: this.event.questions && this.event.questions.length > 0 ? 'ProjectExtraDetails' : 'CreateProjectCompleted',
+            name: this.event.questions && this.event.questions.length > 0 ? `${nextRouteNamePrefix}ProjectExtraDetails` : 'CreateProjectCompleted',
             params: {
               eventSlug: this.event.slug,
               projectId: project.id,

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -17,6 +17,9 @@ const Admin = () => import(/* webpackChunkName: "admin" */ '@/admin/Base');
 const AdminLogin = () => import(/* webpackChunkName: "admin" */ '@/admin/auth/Login');
 const AdminProjectsList = () => import(/* webpackChunkName: "admin" */ '@/admin/projects/List');
 const AdminProjectsView = () => import(/* webpackChunkName: "admin" */ '@/admin/projects/View');
+const AdminProjectsEdit = () => import(/* webpackChunkName: "admin" */ '@/admin/projects/Edit');
+const AdminProjectExtraDetails = () =>
+  import(/* webpackChunkName: "admin" */ '@/admin/projects/ExtraDetails');
 const AdminProjectsStats = () => import(/* webpackChunkName: "admin" */ '@/admin/projects/Stats');
 
 Vue.use(Router);
@@ -128,6 +131,18 @@ export default new Router({
               path: 'projects/:projectId',
               name: 'AdminProjectsView',
               component: AdminProjectsView,
+              props: true,
+            },
+            {
+              path: 'projects/:projectId/edit',
+              name: 'AdminProjectsEdit',
+              component: AdminProjectsEdit,
+              props: true,
+            },
+            {
+              path: 'projects/:projectId/extra',
+              name: 'AdminProjectExtraDetails',
+              component: AdminProjectExtraDetails,
               props: true,
             },
             {

--- a/client/test/unit/specs/project/ExtraDetails.spec.js
+++ b/client/test/unit/specs/project/ExtraDetails.spec.js
@@ -77,40 +77,86 @@ describe('Project ExtraDetails component', () => {
     });
 
     describe('onSubmit', async () => {
-      // ARRANGE
-      const answers = { baz: true };
-      vm.answers = answers;
-      vm.eventSlug = 'slug';
-      vm.event = { id: 'foo' };
-      vm.projectId = 'bar';
-      vm.project = { id: 'bar' };
-      ProjectServiceMock.partialUpdate.withArgs('foo', 'bar', { answers }).resolves();
-      vm.$ga = {
-        event: sandbox.stub(),
-      };
-      vm.$router = {
-        push: sandbox.stub(),
-      };
+      it('should go to the create project completed page', async () => {
+        // ARRANGE
+        const answers = { baz: true };
+        vm.answers = answers;
+        vm.eventSlug = 'slug';
+        vm.event = { id: 'foo' };
+        vm.projectId = 'bar';
+        vm.project = { id: 'bar' };
+        ProjectServiceMock.partialUpdate.withArgs('foo', 'bar', { answers }).resolves();
+        vm.$ga = {
+          event: sandbox.stub(),
+        };
+        vm.$router = {
+          push: sandbox.stub(),
+        };
+        vm.$route = {
+          path: '',
+        };
 
-      // ACT
-      await vm.onSubmit();
+        // ACT
+        await vm.onSubmit();
 
-      // ASSERT
-      expect(this.$ga.event).to.have.been.calledOnce;
-      expect(this.$ga.event).to.have.been.calledWith({
-        eventCategory: 'ProjectRegistration',
-        eventAction: 'ExtraDetailsProvided',
-        eventLabel: 'foo',
+        // ASSERT
+        expect(vm.$ga.event).to.have.been.calledOnce;
+        expect(vm.$ga.event).to.have.been.calledWith({
+          eventCategory: 'ProjectRegistration',
+          eventAction: 'ExtraDetailsProvided',
+          eventLabel: 'foo',
+        });
+        expect(vm.$router.push).to.have.been.calledOnce;
+        expect(vm.$router.push).to.have.been.calledWith({
+          name: 'CreateProjectCompleted',
+          params: {
+            eventSlug: 'slug',
+            projectId: 'bar',
+            _event: { id: 'foo' },
+            _project: { id: 'bar' },
+          },
+        });
       });
-      expect(this.$router.push).to.have.been.calledOnce;
-      expect(this.$router.push).to.have.been.calledWith({
-        name: 'CreateProjectCompleted',
-        params: {
-          eventSlug: 'slug',
-          projectId: 'bar',
-          _event: { id: 'foo' },
-          _project: { id: 'bar' },
-        },
+
+      it('should go to the admin project list view if the route is admin', async () => {
+        // ARRANGE;
+        const answers = { baz: true };
+        vm.answers = answers;
+        vm.eventSlug = 'slug';
+        vm.event = { id: 'foo' };
+        vm.projectId = 'bar';
+        vm.project = { id: 'bar' };
+        ProjectServiceMock.partialUpdate.withArgs('foo', 'bar', { answers }).resolves();
+        vm.$ga = {
+          event: sandbox.stub(),
+        };
+        vm.$router = {
+          push: sandbox.stub(),
+        };
+        vm.$route = {
+          path: '/admin/...',
+        };
+
+        // ACT
+        await vm.onSubmit();
+
+        // ASSERT
+        expect(vm.$ga.event).to.have.been.calledOnce;
+        expect(vm.$ga.event).to.have.been.calledWith({
+          eventCategory: 'ProjectRegistration',
+          eventAction: 'ExtraDetailsProvided',
+          eventLabel: 'foo',
+        });
+        expect(vm.$router.push).to.have.been.calledOnce;
+        expect(vm.$router.push).to.have.been.calledWith({
+          name: 'AdminProjects',
+          params: {
+            eventSlug: 'slug',
+            projectId: 'bar',
+            _event: { id: 'foo' },
+            _project: { id: 'bar' },
+          },
+        });
       });
     });
   });

--- a/client/test/unit/specs/project/Form.spec.js
+++ b/client/test/unit/specs/project/Form.spec.js
@@ -316,6 +316,9 @@ describe('ProjectForm component', () => {
         vm.$router = {
           push: sandbox.stub(),
         };
+        vm.$route = {
+          path: '',
+        };
 
         // ACT
         await vm.onSubmit();
@@ -362,6 +365,9 @@ describe('ProjectForm component', () => {
         vm.submitted = false;
         vm.$router = {
           push: sandbox.stub(),
+        };
+        vm.$route = {
+          path: '',
         };
 
         // ACT
@@ -425,6 +431,9 @@ describe('ProjectForm component', () => {
         vm.$validator = {
           validateAll: sandbox.stub().resolves(true),
         };
+        vm.$route = {
+          path: '',
+        };
 
         // ACT
         await vm.onSubmit();
@@ -433,6 +442,52 @@ describe('ProjectForm component', () => {
         expect(vm.$router.push).to.have.been.calledOnce;
         expect(vm.$router.push).to.have.been.calledWith({
           name: 'ProjectExtraDetails',
+          params: {
+            eventSlug: 'foo',
+            projectId: 'baz',
+            _event: event,
+            _project: createdProject,
+          },
+        });
+      });
+
+      it('should go to the admin extra details page if the route is admin', async () => {
+        // ARRANGE
+        const event = {
+          slug: 'foo',
+          questions: ['a', 'b'],
+        };
+        const project = {
+          name: 'bar',
+          supervisor: { type: 'supervisor' },
+          members: [
+            {
+              type: 'member',
+            },
+          ],
+        };
+        const createdProject = { id: 'baz' };
+        vm.event = event;
+        vm.projectPayload = project;
+        sandbox.stub(vm, 'register').resolves(createdProject);
+        sandbox.stub(window, 'removeEventListener');
+        vm.$router = {
+          push: sandbox.stub(),
+        };
+        vm.$validator = {
+          validateAll: sandbox.stub().resolves(true),
+        };
+        vm.$route = {
+          path: '/admin/',
+        };
+
+        // ACT
+        await vm.onSubmit();
+
+        // ASSERT
+        expect(vm.$router.push).to.have.been.calledOnce;
+        expect(vm.$router.push).to.have.been.calledWith({
+          name: 'AdminProjectExtraDetails',
           params: {
             eventSlug: 'foo',
             projectId: 'baz',


### PR DESCRIPTION
Add two new routes under the admin namespace:
```
/admin/events/cp-2018/projects/:id/edit
/admin/events/cp-2018/projects/:id/extra
```
These render new components with a warning message to the admin that they are editing a live project and then the existing component.
