### PR TITLE
Remove wild .only from server int test

### DIFF
--- a/server/test/integration/routes/projects.spec.js
+++ b/server/test/integration/routes/projects.spec.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 
 dbConfig['@global'] = true;
 dbConfig['@noCallThru'] = true;
-describe.only('integration: projects with open event by default', () => {
+describe('integration: projects with open event by default', () => {
   let app;
   let token;
   let eventId;


### PR DESCRIPTION
Tests are still passing anyway, but it shouldn't have been here in the first place