### PR TITLE
Don't include deleted projects in admin listing

### DIFF
--- a/server/controllers/projects.js
+++ b/server/controllers/projects.js
@@ -92,6 +92,7 @@ class Project {
           const value = query.scopes[field];
           qb.andWhere(snakeCase(field), '=', value);
         });
+        qb.andWhere('project.deleted_at', 'IS', null);
       })
       .orderBy(query.orderBy ? snakeCase(query.orderBy) : 'created_at', query.ascending === '1' ? 'asc' : 'desc');
     if (paginated) {

--- a/server/test/integration/routes/projects.spec.js
+++ b/server/test/integration/routes/projects.spec.js
@@ -649,6 +649,22 @@ describe('integration: projects with open event by default', () => {
         .expect(403);
     });
 
+    it("shouldn't include deleted projects", async () => {
+      await request(app)
+        .get(`/api/v1/events/${eventId}/projects?limit=1&token=${refAuth.token}`)
+        .expect(200)
+        .then(async (res) => {
+          const lastProject = res.body.data[0];
+          await util.project.delete(refAuth.token, eventId, lastProject);
+          await request(app)
+            .get(`/api/v1/events/${eventId}/projects?limit=1&token=${refAuth.token}`)
+            .expect(200)
+            .then((r) => {
+              expect(r.body.data[0].id).to.not.equal(lastProject.id);
+            });
+        });
+    });
+
     describe('with csv format', () => {
       it('should return a csv', async () => {
         await request(app)

--- a/server/test/integration/utils.js
+++ b/server/test/integration/utils.js
@@ -1,3 +1,4 @@
+const moment = require('moment');
 const request = require('supertest');
 
 module.exports = (app) => {
@@ -41,8 +42,16 @@ module.exports = (app) => {
   }
 
   function getProject(token, eventId, projectId) {
+    return request(app).get(`/api/v1/events/${eventId}/projects/${projectId}?token=${token}`);
+  }
+
+  function deleteProject(token, eventId, project) {
     return request(app)
-      .get(`/api/v1/events/${eventId}/projects/${projectId}?token=${token}`);
+      .put(`/api/v1/events/${eventId}/projects/${project.id}?token=${token}`)
+      .send({
+        deletedAt: moment().format(),
+        users: project.members.concat(project.supervisor),
+      });
   }
 
   function getEvent(slug) {
@@ -87,6 +96,7 @@ module.exports = (app) => {
       create: createProject,
       update: updateProject,
       get: getProject,
+      delete: deleteProject,
     },
   };
 };

--- a/server/test/unit/controllers/projects.spec.js
+++ b/server/test/unit/controllers/projects.spec.js
@@ -327,8 +327,8 @@ describe('projects controllers', () => {
       await controllers.getExtended({ scopes: { event_id: 'event1' } }, true);
       expect(projectInstance.joinView).to.have.been.calledOnce;
       expect(projectInstance.joinView).to.have.been.calledWith(undefined);
-      expect(projectInstance.andWhere).to.have.been.calledOnce;
-      expect(projectInstance.andWhere).to.have.been.calledWith('event_id', '=', 'event1');
+      expect(projectInstance.andWhere).to.have.been.calledTwice;
+      expect(projectInstance.andWhere.firstCall).to.have.been.calledWith('event_id', '=', 'event1');
       expect(projectInstance.orderBy).to.have.been.calledWith('created_at', 'desc');
       expect(projectInstance.fetchPage).to.have.been.calledWith({ pageSize: 25, page: 1, withRelated: ['owner', 'supervisor', 'members'] });
     });
@@ -357,8 +357,12 @@ describe('projects controllers', () => {
       }, true);
       expect(projectInstance.joinView).to.have.been.calledOnce;
       expect(projectInstance.joinView).to.have.been.calledWith({ name: 'aa' });
-      expect(projectInstance.andWhere).to.have.been.calledTwice;
-      expect(projectInstance.andWhere.getCall(0)).to.have.been.calledWith('event_id', '=', 'event1');
+      expect(projectInstance.andWhere).to.have.been.calledThrice;
+      expect(projectInstance.andWhere.getCall(0)).to.have.been.calledWith(
+        'event_id',
+        '=',
+        'event1',
+      );
       expect(projectInstance.andWhere.getCall(1)).to.have.been.calledWith('owner.id', '=', 'user1');
       expect(projectInstance.orderBy).to.have.been.calledWith('banana_split', 'asc');
       expect(projectInstance.fetchPage).to.have.been.calledWith({ pageSize: 30, page: 2, withRelated: ['owner', 'supervisor', 'members'] });


### PR DESCRIPTION
add `AND project.deleted_at IS null` to not include any soft deleted projects in the results.

I've spent ages looking at the tests for this, It would be nice if we could add some integration tests but I've struggled to find a way of doing it without a big refactor. The util used to create projects actually hits the real API rather than seeding them directly in the DB: `https://github.com/CoderDojo/coolest-platform/blob/hide-deleted-projects/server/test/integration/utils.js#L5`

The created endpoint (rightly IMO) doesn't allow the creation of deleted projects, so I'm not sure of the best way to do this, thoughts?