### PR TITLE
Upgrade sinon and remove deprecation warning

### DIFF
--- a/client/test/unit/specs/admin/auth/Login.spec.js
+++ b/client/test/unit/specs/admin/auth/Login.spec.js
@@ -7,7 +7,7 @@ describe('AdminLogin component', () => {
   let MockAdminAuthService;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     MockAdminAuthService = {
       login: sandbox.stub(),
     };

--- a/client/test/unit/specs/admin/auth/service.spec.js
+++ b/client/test/unit/specs/admin/auth/service.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import AdminAuthService from '@/admin/auth/service';
 
 describe('Admin Auth service', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.reset();

--- a/client/test/unit/specs/admin/projects/List.spec.js
+++ b/client/test/unit/specs/admin/projects/List.spec.js
@@ -7,7 +7,7 @@ describe('Admin Projects List component', () => {
   let MockAdminEventsService;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     MockAdminEventsService = {
       sendConfirmAttendanceEmails: sandbox.stub(),
     };

--- a/client/test/unit/specs/admin/projects/Stats.spec.js
+++ b/client/test/unit/specs/admin/projects/Stats.spec.js
@@ -70,7 +70,7 @@ describe('AdminProjectStats component', () => {
   const project9 = { org: 'codeclub' };
 
   beforeEach(() => {
-    // sandbox = sinon.sandbox.create();
+    // sandbox = sinon.createSandbox();
     vm = vueUnitHelper(AdminProjectStats());
     vm.users = [
       user1,

--- a/client/test/unit/specs/auth/service.spec.js
+++ b/client/test/unit/specs/auth/service.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import AuthService from '@/auth/service';
 
 describe('Auth service', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.reset();

--- a/client/test/unit/specs/event/Auth.spec.js
+++ b/client/test/unit/specs/event/Auth.spec.js
@@ -8,7 +8,7 @@ describe('Auth component', () => {
   let vm;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     CookieMock = {
       set: sandbox.stub(),
     };

--- a/client/test/unit/specs/event/EventService.spec.js
+++ b/client/test/unit/specs/event/EventService.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import EventService from '@/event/service';
 
 describe('Event service', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.reset();

--- a/client/test/unit/specs/event/EventUtilsMixin.spec.js
+++ b/client/test/unit/specs/event/EventUtilsMixin.spec.js
@@ -6,7 +6,7 @@ describe('Event mixin', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     vm = vueUnitHelper(EventUtils);
   });
 

--- a/client/test/unit/specs/event/FetchEventMixin.spec.js
+++ b/client/test/unit/specs/event/FetchEventMixin.spec.js
@@ -8,7 +8,7 @@ describe('Fetch Event mixin', () => {
   let vm;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     EventServiceMock = {
       get: sandbox.stub(),
     };

--- a/client/test/unit/specs/project/CreateCompleted.spec.js
+++ b/client/test/unit/specs/project/CreateCompleted.spec.js
@@ -6,7 +6,7 @@ describe('Create Project Completed component', () => {
   let vm;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     vm = vueUnitHelper(CreateProjectCompleted({}));
   });
 

--- a/client/test/unit/specs/project/ExtraDetails.spec.js
+++ b/client/test/unit/specs/project/ExtraDetails.spec.js
@@ -7,7 +7,7 @@ describe('Project ExtraDetails component', () => {
   let ProjectServiceMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ProjectServiceMock = {
       partialUpdate: sandbox.stub(),
     };

--- a/client/test/unit/specs/project/FetchProjectMixin.spec.js
+++ b/client/test/unit/specs/project/FetchProjectMixin.spec.js
@@ -7,7 +7,7 @@ describe('Fetch Project mixin', () => {
   let vm;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ProjectServiceMock = {
       get: sandbox.stub(),
     };

--- a/client/test/unit/specs/project/Form.spec.js
+++ b/client/test/unit/specs/project/Form.spec.js
@@ -9,7 +9,7 @@ describe('ProjectForm component', () => {
   let ProjectServiceMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ProjectServiceMock = {
       create: sandbox.stub(),
       update: sandbox.stub(),

--- a/client/test/unit/specs/project/List.spec.js
+++ b/client/test/unit/specs/project/List.spec.js
@@ -3,7 +3,7 @@ import ProjectList from '!!vue-loader?inject!@/project/List';
 
 describe('ProjectList component', () => {
   let vm;
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   const ProjectServiceMock = {
     list: sandbox.stub(),
   };

--- a/client/test/unit/specs/project/ProjectStatus.spec.js
+++ b/client/test/unit/specs/project/ProjectStatus.spec.js
@@ -7,7 +7,7 @@ describe('Project Status component', () => {
   let vm;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ProjectService = {
       status: {
         update: sandbox.stub(),

--- a/client/test/unit/specs/project/service.spec.js
+++ b/client/test/unit/specs/project/service.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import ProjectService from '@/project/service';
 
 describe('Project service', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.reset();

--- a/client/test/unit/specs/router/adminNavGuard.spec.js
+++ b/client/test/unit/specs/router/adminNavGuard.spec.js
@@ -13,7 +13,7 @@ describe('adminNavGuard', () => {
   };
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     MockAdminAuthService = {
       checkToken: sandbox.stub(),
     };

--- a/client/test/unit/specs/router/userAuthNavGuard.spec.js
+++ b/client/test/unit/specs/router/userAuthNavGuard.spec.js
@@ -10,7 +10,7 @@ describe('adminNavGuard', () => {
   let fromStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     toStub = {
       path: '/admin',
       params: {},

--- a/client/test/unit/specs/user/service.spec.js
+++ b/client/test/unit/specs/user/service.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import UserService from '@/user/service';
 
 describe('User service', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.reset();

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",
     "shelljs": "^0.7.8",
-    "sinon": "^4.0.1",
+    "sinon": "^7.1.1",
     "sinon-chai": "^2.14.0",
     "sqlite3": "^3.1.13",
     "supertest": "^3.0.0",

--- a/server/test/unit/authorisations/projects.spec.js
+++ b/server/test/unit/authorisations/projects.spec.js
@@ -3,7 +3,7 @@ const acl = require('acl');
 
 describe('authorisations: project', () => {
   describe('isAllowed', () => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const utils = {};
     let authorisations;
     afterEach(() => {

--- a/server/test/unit/authorisations/utils.spec.js
+++ b/server/test/unit/authorisations/utils.spec.js
@@ -2,7 +2,7 @@ const authorisations = require('../../../routes/authorisations/utils');
 
 describe('utils', () => {
   describe('isAllowed', () => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const areAnyRolesAllowed = sandbox.stub();
     const aclMock = {
       areAnyRolesAllowed,

--- a/server/test/unit/controllers/auth.spec.js
+++ b/server/test/unit/controllers/auth.spec.js
@@ -3,7 +3,7 @@ const jsonwebtoken = require('jsonwebtoken');
 const config = require('../../../config/auth');
 
 describe('auth controllers', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   const userModel = {};
   describe('authenticate', () => {
     beforeEach(() => {

--- a/server/test/unit/controllers/events.spec.js
+++ b/server/test/unit/controllers/events.spec.js
@@ -2,7 +2,7 @@ const proxy = require('proxyquire').noCallThru();
 const uuid = require('uuid/v4');
 
 describe('events controllers', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   describe('get', () => {
     beforeEach(() => {
       sandbox.reset();

--- a/server/test/unit/controllers/mailing.spec.js
+++ b/server/test/unit/controllers/mailing.spec.js
@@ -1,7 +1,7 @@
 const proxy = require('proxyquire').noCallThru();
 
 describe('mailing controllers', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   describe('get', () => {
     let setSubstitutionWrappersStub;
     let sendStub;

--- a/server/test/unit/controllers/projects.setSeating.spec.js
+++ b/server/test/unit/controllers/projects.setSeating.spec.js
@@ -9,7 +9,7 @@ describe('projects controllers: setSeatingPerCategory', () => {
   const seatModel = {};
   let seatModelConstructor;
   before(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   beforeEach(() => {
     projectModel.ageGroup = sandbox.stub().returns(projectModel);

--- a/server/test/unit/controllers/projects.setSeatingPerCategory.spec.js
+++ b/server/test/unit/controllers/projects.setSeatingPerCategory.spec.js
@@ -4,7 +4,7 @@ describe('projects controllers: setSeatingPerCategory', () => {
   let controllers;
   let sandbox;
   before(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     controllers = proxy('../../../controllers/projects', {
       '../models/user': {},
       '../models/project': {},

--- a/server/test/unit/controllers/projects.spec.js
+++ b/server/test/unit/controllers/projects.spec.js
@@ -4,7 +4,7 @@ const {
 } = require('lodash');
 
 describe('projects controllers', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   describe('post', () => {
     let creatorMock;
     before(() => {

--- a/server/test/unit/controllers/users.spec.js
+++ b/server/test/unit/controllers/users.spec.js
@@ -1,7 +1,7 @@
 const proxy = require('proxyquire').noCallThru();
 
 describe('users controllers', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
     sandbox.reset();

--- a/server/test/unit/models/auth.spec.js
+++ b/server/test/unit/models/auth.spec.js
@@ -6,7 +6,7 @@ const config = require('../../../config/auth');
 
 let Auth;
 describe('auth model', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   before(async () => {
     Auth = proxy('../../../models/auth', {
       '../database': {},

--- a/server/test/unit/models/project.spec.js
+++ b/server/test/unit/models/project.spec.js
@@ -2,7 +2,7 @@ const proxy = require('proxyquire');
 
 let Project;
 describe('auth model', () => {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   const logger = {};
   const db = {};
   before(async () => {

--- a/server/test/unit/models/user.spec.js
+++ b/server/test/unit/models/user.spec.js
@@ -5,7 +5,7 @@ describe('user model', () => {
   let sandbox;
 
   before(async () => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     User = proxy('../../../models/user', {
       '../database': {},
     });

--- a/server/test/unit/routes/events.postSeating.spec.js
+++ b/server/test/unit/routes/events.postSeating.spec.js
@@ -9,7 +9,7 @@ describe('router: event', () => {
     let sandbox;
     let next;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/events', {
         '../../controllers/projects': projectController,
         '../../controllers/events': eventController,

--- a/server/test/unit/routes/events.spec.js
+++ b/server/test/unit/routes/events.spec.js
@@ -13,7 +13,7 @@ describe('router: events', () => {
   let nextMock;
 
   before(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     handlers = proxy('../../../routes/handlers/events', {
       '../../controllers/events': eventController,
       '../../controllers/projects': projectController,

--- a/server/test/unit/routes/projects.patch.spec.js
+++ b/server/test/unit/routes/projects.patch.spec.js
@@ -8,7 +8,7 @@ describe('router: project', () => {
     let sandbox;
     let errorHandler;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
       })).patchStatus;

--- a/server/test/unit/routes/projects.spec.js
+++ b/server/test/unit/routes/projects.spec.js
@@ -15,7 +15,7 @@ describe('router: project', () => {
     let nextMock;
     let errorHandler;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
       })).post;
@@ -199,7 +199,7 @@ describe('router: project', () => {
     const projectController = class {};
     let sandbox;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handler = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
       })).param;
@@ -230,7 +230,7 @@ describe('router: project', () => {
     let sandbox;
 
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
       })).get;
@@ -262,7 +262,7 @@ describe('router: project', () => {
   describe('GET /', () => {
     let handler;
     const projectController = class {};
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const CSVHeader = sandbox.spy(projectCSVHeader);
 
     before(() => {
@@ -452,7 +452,7 @@ describe('router: project', () => {
     let sandbox;
     let errorHandler;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
         '../../controllers/users': userController,
@@ -695,7 +695,7 @@ describe('router: project', () => {
     let sandbox;
     let errorHandler;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
       })).patch;
@@ -773,7 +773,7 @@ describe('router: project', () => {
     let errorHandler;
     const projectController = class {};
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/projects', {
         '../../controllers/projects': projectController,
       })).getUserProjects;

--- a/server/test/unit/routes/users.spec.js
+++ b/server/test/unit/routes/users.spec.js
@@ -19,7 +19,7 @@ describe('router: user', () => {
     let nextMock;
     let errorHandler;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/users', {
         '../../controllers/users': userController,
         '../../controllers/auth': authController,
@@ -226,7 +226,7 @@ describe('router: user', () => {
     let jsonStub;
     let errorHandler;
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       handlers = (proxy('../../../routes/handlers/users', {
         '../../controllers/users': userController,
         '../../controllers/auth': authController,

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,23 +143,27 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@sinonjs/formatio@3.0.0":
+"@sinonjs/commons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
   dependencies:
     "@sinonjs/samsam" "2.1.0"
-
-"@sinonjs/formatio@^2.0.0":
-  version "2.0.0"
-  resolved "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
-  dependencies:
-    samsam "1.3.0"
 
 "@sinonjs/samsam@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
   dependencies:
     array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
 
 "@types/caseless@*":
   version "0.12.1"
@@ -2629,7 +2633,7 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
-diff@^3.1.0:
+diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -5693,9 +5697,13 @@ lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
-lolex@^2.2.0, lolex@^2.3.2:
+lolex@^2.3.2:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -6174,7 +6182,7 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
-nise@^1.2.0:
+nise@^1.4.6:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.6.tgz#76cc3915925056ae6c405dd8ad5d12bde570c19f"
   dependencies:
@@ -7920,10 +7928,6 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-samsam@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
-
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -8111,17 +8115,19 @@ sinon-chai@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.14.0.tgz#da7dd4cc83cd6a260b67cca0f7a9fdae26a1205d"
 
-sinon@^4.0.1:
-  version "4.5.0"
-  resolved "http://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
+sinon@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.1.1.tgz#1202f317aa14d93cb9b69ff50b6bd49c0e05ffc9"
   dependencies:
-    "@sinonjs/formatio" "^2.0.0"
-    diff "^3.1.0"
+    "@sinonjs/commons" "^1.2.0"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.2"
+    diff "^3.5.0"
     lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^5.1.0"
-    type-detect "^4.0.5"
+    lolex "^3.0.0"
+    nise "^1.4.6"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -8547,7 +8553,7 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
@@ -8836,7 +8842,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 


### PR DESCRIPTION
Sandboxes were being reworked. Rather than removing the "restore" function like recommened in 4.x, upgrading to 7.x and changing the constructor makes more sense :)