### PR TITLE
Export a new representation of projects

### DIFF
--- a/client/src/admin/projects/List.vue
+++ b/client/src/admin/projects/List.vue
@@ -10,7 +10,10 @@
         </select>
       </li>
       <li class="nav-item">
-        <a :href="csvUrl" :download="`${eventSlug}-export.csv`" class="nav-link">Export CSV</a>
+        <a :href="projectCSVUrl" :download="`${eventSlug}-projects-export.csv`" class="nav-link">Export Projects CSV</a>
+      </li>
+      <li class="nav-item">
+        <a :href="userCSVUrl" :download="`${eventSlug}-members-export.csv`" class="nav-link">Export Members CSV</a>
       </li>
       <li class="nav-item">
         <a v-show="confirmationEmailSendState === 'visible'" href="#" @click.prevent="sendConfirmAttendanceEmails" class="nav-link">Send Confirmation Emails</a>
@@ -168,7 +171,7 @@
       token() {
         return localStorage.getItem('authToken');
       },
-      csvUrl() {
+      CSVQueryString() {
         if (!this.tableState.query) return '';
         let queryStr = '';
         Object.keys(this.tableState.query).forEach((key) => {
@@ -186,7 +189,15 @@
         if (this.tableState.byColumn) {
           queryStr += `&byColumn=${encodeURIComponent(this.tableState.byColumn)}`;
         }
+        return queryStr;
+      },
+      projectCSVUrl() {
+        const queryStr = this.CSVQueryString;
         return `/api/v1/events/${this.event.id}/projects?format=csv&token=${this.token}${queryStr}`;
+      },
+      userCSVUrl() {
+        const queryStr = this.CSVQueryString;
+        return `/api/v1/events/${this.event.id}/projects?view=user&format=csv&token=${this.token}${queryStr}`;
       },
     },
     watch: {

--- a/client/test/unit/specs/admin/projects/List.spec.js
+++ b/client/test/unit/specs/admin/projects/List.spec.js
@@ -77,19 +77,17 @@ describe('Admin Projects List component', () => {
       });
     });
 
-    describe('csvUrl', () => {
+    describe('CSVQueryString', () => {
       it('should return an empty string if tableState does not have a query', () => {
         // ARRANGE
         vm.tableState = {};
 
         // ASSERT
-        expect(vm.csvUrl).to.equal('');
+        expect(vm.CSVQueryString).to.equal('');
       });
 
       it('should query params for fields with values', () => {
         // ARRANGE
-        vm.event = { id: 'foo' };
-        vm.token = 'bar';
         vm.tableState = {
           query: {
             name: 'baz',
@@ -99,43 +97,35 @@ describe('Admin Projects List component', () => {
         };
 
         // ASSERT
-        expect(vm.csvUrl).to.equal('/api/v1/events/foo/projects?format=csv&token=bar&query[name]=baz&query[email]=someone%40example.com');
+        expect(vm.CSVQueryString).to.equal('&query[name]=baz&query[email]=someone%40example.com');
       });
 
       it('should include orderBy if tableState contains it', () => {
         // ARRANGE
-        vm.event = { id: 'foo' };
-        vm.token = 'bar';
         vm.tableState = { query: {}, orderBy: 'category' };
 
         // ASSERT
-        expect(vm.csvUrl).to.equal('/api/v1/events/foo/projects?format=csv&token=bar&orderBy=category');
+        expect(vm.CSVQueryString).to.equal('&orderBy=category');
       });
 
       it('should include ascending if tableState contains it', () => {
         // ARRANGE
-        vm.event = { id: 'foo' };
-        vm.token = 'bar';
         vm.tableState = { query: {}, ascending: '1' };
 
         // ASSERT
-        expect(vm.csvUrl).to.equal('/api/v1/events/foo/projects?format=csv&token=bar&ascending=1');
+        expect(vm.CSVQueryString).to.equal('&ascending=1');
       });
 
       it('should include byColumn if tableState contains it', () => {
         // ARRANGE
-        vm.event = { id: 'foo' };
-        vm.token = 'bar';
         vm.tableState = { query: {}, byColumn: '1' };
 
         // ASSERT
-        expect(vm.csvUrl).to.equal('/api/v1/events/foo/projects?format=csv&token=bar&byColumn=1');
+        expect(vm.CSVQueryString).to.equal('&byColumn=1');
       });
 
       it('should support all query params together', () => {
         // ARRANGE
-        vm.event = { id: 'foo' };
-        vm.token = 'bar';
         vm.tableState = {
           query: {
             name: 'baz',
@@ -148,7 +138,23 @@ describe('Admin Projects List component', () => {
         };
 
         // ASSERT
-        expect(vm.csvUrl).to.equal('/api/v1/events/foo/projects?format=csv&token=bar&query[name]=baz&query[email]=someone%40example.com&orderBy=category&ascending=1&byColumn=1');
+        expect(vm.CSVQueryString).to.equal('&query[name]=baz&query[email]=someone%40example.com&orderBy=category&ascending=1&byColumn=1');
+      });
+    });
+    describe('userCSVUrl', () => {
+      it('should prefix CSVQueryString with its default params', () => {
+        vm.CSVQueryString = '&query[name]=baz&query[email]=someone%40example.com&orderBy=category&ascending=1&byColumn=1';
+        vm.event = { id: 'foo' };
+        vm.token = 'bar';
+        expect(vm.userCSVUrl).to.be.equal('/api/v1/events/foo/projects?view=user&format=csv&token=bar&query[name]=baz&query[email]=someone%40example.com&orderBy=category&ascending=1&byColumn=1');
+      });
+    });
+    describe('projectCSVUrl', () => {
+      it('should prefix CSVQueryString with its default params', () => {
+        vm.CSVQueryString = '&query[name]=baz&query[email]=someone%40example.com&orderBy=category&ascending=1&byColumn=1';
+        vm.event = { id: 'foo' };
+        vm.token = 'bar';
+        expect(vm.projectCSVUrl).to.be.equal('/api/v1/events/foo/projects?format=csv&token=bar&query[name]=baz&query[email]=someone%40example.com&orderBy=category&ascending=1&byColumn=1');
       });
     });
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       HOSTNAME: 'http://platform.local'
     ports:
       - 8080:8080
+      - 9229:9229
     volumes:
       - ./:/usr/src/app/
     depends_on:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "node client/build/build.js",
     "start": "concurrently --kill-others --success first \"yarn server-start\" \"yarn client-start\"",
-    "start-dev": "concurrently --kill-others --success first \"yarn server-start --seed --trace-sync-io\" \"yarn client-start\"",
+    "start-dev": "concurrently --kill-others --success first \"yarn server-start-dev --seed --trace-sync-io\" \"yarn client-start\"",
     "start-with-mocks": "concurrently --kill-others --success first \"yarn mock-server\" \"yarn client-start\" ",
     "test": "yarn client-unit && yarn server-unit && yarn server-int",
     "lint": "eslint --ext .js,.vue .",
@@ -19,6 +19,7 @@
     "client-lint": "eslint --ext .js,.vue src client/test/unit/specs",
     "mock-server": "node ./client/mock-server/server.js",
     "server-start": "cd server && node bin/www",
+    "server-start-dev": "cd server && node --inspect=0.0.0.0 bin/www",
     "server-unit": "HOSTNAME=http://platform.local mocha -t 3000 -c --require ./server/test/helper.js ./server/test/unit --recursive --reporter=nyan --forbid-pending",
     "server-int": "NODE_ENV=test mocha -t 10000 -c --require ./server/test/helper.js ./server/test/integration --recursive --reporter=nyan --forbid-pending",
     "server-lint": "eslint server --env mocha,chai --global expect,sinon"

--- a/server/models/CSVHeader.js
+++ b/server/models/CSVHeader.js
@@ -1,0 +1,16 @@
+module.exports = class CSVHeader {
+  constructor(questions) {
+    this.questions = questions;
+  }
+  get questionFields() {
+    return (this.questions || []).map((question) => {
+      return {
+        label: `${question[0].toUpperCase()}${question.slice(1)}`.replace(/(_)/g, ' '),
+        value: `answers.${question}`,
+      };
+    });
+  }
+  static dateFormat(date) {
+    return new Date(date).toLocaleDateString();
+  }
+};

--- a/server/models/projectCSVHeader.js
+++ b/server/models/projectCSVHeader.js
@@ -1,40 +1,44 @@
-const projectCSVHeader = (questions, nbParticipants) => {
-  const dateFormat = date => new Date(date).toLocaleDateString();
-  const questionFields = (questions || []).map((question) => {
-    return {
-      label: `${question[0].toUpperCase()}${question.slice(1)}`.replace(/(_)/g, ' '),
-      value: `answers.${question}`,
-    };
-  });
-  let fields = [
-    { label: 'Name', value: 'name' },
-    { label: 'Description', value: 'description' },
-    { label: 'Category', value: 'category' },
-    { label: 'Owner Email', value: 'owner.email' },
-    { label: 'Seat', value: 'seat.seat' },
-    { label: 'Status', value: 'status' },
-    { label: 'Created At', value: row => dateFormat(row.createdAt) },
-    { label: 'Updated At', value: row => dateFormat(row.updatedAt) },
-    { label: 'Supervisor First Name', value: 'supervisor.firstName' },
-    { label: 'Supervisor Last Name', value: 'supervisor.lastName' },
-    { label: 'Supervisor Email', value: 'supervisor.email' },
-    { label: 'Supervisor Phone', value: 'supervisor.phone' },
-  ];
-  fields = fields.concat(questionFields);
-  for (let i = 0; i < nbParticipants; i += 1) {
-    const member = [
-      { label: `Participant ${i + 1} First Name`, value: `members[${i}].firstName` },
-      { label: `Participant ${i + 1} Last Name`, value: `members[${i}].lastName` },
-      { label: `Participant ${i + 1} Dob`, value: `members[${i}].dob` },
-      { label: `Participant ${i + 1} Gender`, value: `members[${i}].gender` },
-      {
-        label: `Participant ${i + 1} Special requirements`,
-        value: `members[${i}].specialRequirements`,
-      },
-    ];
-    fields = fields.concat(member);
-  }
-  return fields;
-};
+const CSVHeader = require('./CSVHeader');
 
-module.exports = projectCSVHeader;
+module.exports = class ProjectCSVHeader extends CSVHeader {
+  constructor(questions, nbParticipants) {
+    super(questions);
+    this.nbParticipants = nbParticipants;
+  }
+  get fields() {
+    let fields = [
+      { label: 'Project name', value: 'name' },
+      { label: 'Description', value: 'description' },
+      { label: 'Category', value: 'category' },
+      { label: 'Owner Email', value: 'owner.email' },
+      { label: 'Seat', value: 'seat.seat' },
+      { label: 'Status', value: 'status' },
+      { label: 'Created At', value: row => ProjectCSVHeader.dateFormat(row.createdAt) },
+      { label: 'Updated At', value: row => ProjectCSVHeader.dateFormat(row.updatedAt) },
+      { label: 'Supervisor First Name', value: 'supervisor.firstName' },
+      { label: 'Supervisor Last Name', value: 'supervisor.lastName' },
+      { label: 'Supervisor Email', value: 'supervisor.email' },
+      { label: 'Supervisor Phone', value: 'supervisor.phone' },
+    ];
+    fields = fields.concat(this.questionFields);
+    fields = fields.concat(this.participants);
+    return fields;
+  }
+  get participants() {
+    let participants = [];
+    for (let i = 0; i < this.nbParticipants; i += 1) {
+      const member = [
+        { label: `Participant ${i + 1} First Name`, value: `members[${i}].firstName` },
+        { label: `Participant ${i + 1} Last Name`, value: `members[${i}].lastName` },
+        { label: `Participant ${i + 1} Dob`, value: `members[${i}].dob` },
+        { label: `Participant ${i + 1} Gender`, value: `members[${i}].gender` },
+        {
+          label: `Participant ${i + 1} Special requirements`,
+          value: `members[${i}].specialRequirements`,
+        },
+      ];
+      participants = participants.concat(member);
+    }
+    return participants;
+  }
+};

--- a/server/models/userCSVHeader.js
+++ b/server/models/userCSVHeader.js
@@ -1,0 +1,27 @@
+const CSVHeader = require('./CSVHeader');
+
+module.exports = class UserCSVHeader extends CSVHeader {
+  get fields() {
+    let fields = [
+      { label: 'First name', value: 'firstName' },
+      { label: 'Last name', value: 'lastName' },
+      { label: 'Dob', value: 'dob' },
+      { label: 'Gender', value: 'gender' },
+      { label: 'Special requirements', value: 'specialRequirements' },
+      { label: 'Project name', value: 'name' },
+      { label: 'Description', value: 'description' },
+      { label: 'Category', value: 'category' },
+      { label: 'Owner Email', value: 'owner.email' },
+      { label: 'Seat', value: 'seat.seat' },
+      { label: 'Status', value: 'status' },
+      { label: 'Created At', value: row => UserCSVHeader.dateFormat(row.createdAt) },
+      { label: 'Updated At', value: row => UserCSVHeader.dateFormat(row.updatedAt) },
+      { label: 'Supervisor First Name', value: 'supervisor.firstName' },
+      { label: 'Supervisor Last Name', value: 'supervisor.lastName' },
+      { label: 'Supervisor Email', value: 'supervisor.email' },
+      { label: 'Supervisor Phone', value: 'supervisor.phone' },
+    ];
+    fields = fields.concat(this.questionFields);
+    return fields;
+  }
+};

--- a/server/test/unit/models/CSVHeader.spec.js
+++ b/server/test/unit/models/CSVHeader.spec.js
@@ -1,0 +1,20 @@
+const CSVHeader = require('../../../models/CSVHeader');
+
+describe('project CSV header', () => {
+  let CSV;
+  before(() => {
+    CSV = new CSVHeader(['social_project']);
+  });
+  describe('dateFormat', () => {
+    it('should format a date', () => {
+      const date = CSV.dateFormat('2018-11-14T23:53:00.000Z');
+      expect(date).to.equal('2018-11-14');
+    });
+  });
+  describe('questionFields', () => {
+    it('should transform the questions into supported format for CSV headers', () => {
+      const questions = CSV.questionFields;
+      expect(questions).to.eql([{ label: 'Social project', value: 'answers.social_project' }]);
+    });
+  });
+});

--- a/server/test/unit/models/CSVHeader.spec.js
+++ b/server/test/unit/models/CSVHeader.spec.js
@@ -7,7 +7,7 @@ describe('project CSV header', () => {
   });
   describe('dateFormat', () => {
     it('should format a date', () => {
-      const date = CSV.dateFormat('2018-11-14T23:53:00.000Z');
+      const date = CSVHeader.dateFormat('2018-11-14T23:53:00.000Z');
       expect(date).to.equal('2018-11-14');
     });
   });

--- a/server/test/unit/models/userCSVHeader.spec.js
+++ b/server/test/unit/models/userCSVHeader.spec.js
@@ -1,7 +1,27 @@
-const CSVHeader = require('../../../models/projectCSVHeader');
+const CSVHeader = require('../../../models/userCSVHeader');
 
-describe('project CSV header', () => {
+describe('User CSV header', () => {
   const baseHeader = [
+    {
+      label: 'First name',
+      value: 'firstName',
+    },
+    {
+      label: 'Last name',
+      value: 'lastName',
+    },
+    {
+      label: 'Dob',
+      value: 'dob',
+    },
+    {
+      label: 'Gender',
+      value: 'gender',
+    },
+    {
+      label: 'Special requirements',
+      value: 'specialRequirements',
+    },
     {
       label: 'Project name',
       value: 'name',
@@ -51,30 +71,16 @@ describe('project CSV header', () => {
       value: 'supervisor.phone',
     }];
   const questionsHeader = ['Question 1', 'Question 2'];
-  const participantsHeader = ['Participant 1 First Name', 'Participant 1 Last Name', 'Participant 1 Dob', 'Participant 1 Gender', 'Participant 1 Special requirements']
-    .concat(['Participant 2 First Name', 'Participant 2 Last Name', 'Participant 2 Dob', 'Participant 2 Gender', 'Participant 2 Special requirements']);
 
   it('should return a csv header without participants nor questions', () => {
-    const res = new CSVHeader([], 0).fields;
+    const res = new CSVHeader([]).fields;
     expect(res.map(l => l.label)).to.have.all.members(baseHeader.map(l => l.label));
   });
 
-  it('should return a csv header with participants but no questions', () => {
-    const res = new CSVHeader([], 2).fields;
-    expect(res.map(l => l.label))
-      .to.have.all.members(baseHeader
-        .map(l => l.label).concat(participantsHeader));
-  });
-  it('should return a csv header with no participants but with some questions', () => {
-    const res = new CSVHeader(['question_1', 'question_2'], 0).fields;
+  it('should return a csv header with questions', () => {
+    const res = new CSVHeader(['question_1', 'question_2']).fields;
     expect(res.map(l => l.label))
       .to.have.all.members(baseHeader
         .map(l => l.label).concat(questionsHeader));
-  });
-  it('should return a csv header with participants and questions', () => {
-    const res = new CSVHeader(['question_1', 'question_2'], 2).fields;
-    expect(res.map(l => l.label))
-      .to.have.all.members(baseHeader
-        .map(l => l.label).concat(questionsHeader).concat(participantsHeader));
   });
 });


### PR DESCRIPTION
from users perspective, as CSV
Choice has been made to not expose a new endpoint, considering it would duplicate a lot of code for very few benefits (the querying for this endpoint is one of the most awkward part of this stack due to bookshelf)
