### PR TITLE
Remove html entities for email 'sanitation'

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "express-https-redirect": "^1.0.0",
     "font-awesome": "^4.7.0",
     "helmet": "^3.9.0",
-    "html-entities": "^1.2.1",
     "js-cookie": "^2.2.0",
     "json-server": "^0.12.1",
     "json2csv": "^3.11.5",

--- a/server/controllers/mailing.js
+++ b/server/controllers/mailing.js
@@ -1,5 +1,4 @@
 const mailer = require('@sendgrid/mail');
-const htmlEntities = require('html-entities').AllHtmlEntities;
 const { isEmpty } = require('lodash');
 
 // Examples : https://github.com/sendgrid/sendgrid-nodejs/blob/master/test/typescript/mail.ts
@@ -41,7 +40,7 @@ class Mailing {
         eventLocation: event.location,
         eventWebsite: event.homepage,
         eventManageLink: process.env.HOSTNAME,
-        projectName: htmlEntities.encode(project.name),
+        projectName: project.name,
         ...Mailing.customisationValues(event),
       },
       categories: this.categories.concat([`cp-${event.slug}-registration`]),
@@ -62,7 +61,7 @@ class Mailing {
       },
       subject: 'Welcome back on CP',
       dynamic_template_data: {
-        link: `${process.env.HOSTNAME}/events/${htmlEntities.encode(event.slug)}/my-projects?token=${token}`,
+        link: `${process.env.HOSTNAME}/events/${event.slug}/my-projects?token=${token}`,
         contact: event.contact,
         ...Mailing.customisationValues(event),
       },
@@ -91,7 +90,7 @@ class Mailing {
             // Bugfix for https://github.com/sendgrid/sendgrid-nodejs/issues/747
             substitutions: { },
             dynamic_template_data: {
-              projectName: htmlEntities.encode(project.name),
+              projectName: project.name,
               attendingUrl: `${process.env.HOSTNAME}/events/${event.slug}/projects/${project.id}/status/confirmed`,
               notAttendingUrl: `${process.env.HOSTNAME}/events/${event.slug}/projects/${project.id}/status/canceled`,
               ...customValues,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,7 +4291,7 @@ html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
 
-html-entities@^1.2.0, html-entities@^1.2.1:
+html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 


### PR DESCRIPTION
Seems like the new sendgrid handles html properly now (doesn't parse it)
Closes https://github.com/CoderDojo/coolest-platform/issues/171