### PR TITLE
Initialize form properties to fix validation

### DIFF
--- a/client/src/project/Form.vue
+++ b/client/src/project/Form.vue
@@ -336,9 +336,25 @@
       return {
         dojos: [],
         numParticipants: 1,
-        projectDetails: {},
-        participants: [{ specialRequirementsProvided: false }],
-        supervisor: {},
+        projectDetails: {
+          name: '',
+          description: '',
+          orgRef: '',
+          state: '',
+          city: '',
+        },
+        participants: [{
+          firstName: '',
+          lastName: '',
+          specialRequirements: '',
+          specialRequirementsProvided: false,
+        }],
+        supervisor: {
+          firstName: '',
+          lastName: '',
+          email: '',
+          phone: '',
+        },
         org: undefined,
         submitted: false,
         error: null,
@@ -418,7 +434,12 @@
         const oldLength = this.participants.length;
         if (newLength > oldLength) {
           for (let i = 0; i < newLength - oldLength; i += 1) {
-            this.participants.push({ specialRequirementsProvided: false });
+            this.participants.push({
+              firstName: '',
+              lastName: '',
+              specialRequirements: '',
+              specialRequirementsProvided: false,
+            });
           }
         } else if (newLength < oldLength) {
           this.participants.splice(newLength, oldLength - newLength);

--- a/client/test/unit/specs/project/Form.spec.js
+++ b/client/test/unit/specs/project/Form.spec.js
@@ -229,8 +229,12 @@ describe('ProjectForm component', () => {
       it('should add to the participants array when number increases', () => {
         // ARRANGE
         vm.participants = [
-          { specialRequirementsProvided: false },
-          { specialRequirementsProvided: false },
+          {
+            firstName: '', lastName: '', specialRequirements: '', specialRequirementsProvided: false,
+          },
+          {
+            firstName: '', lastName: '', specialRequirements: '', specialRequirementsProvided: false,
+          },
         ];
 
         // ACT
@@ -238,9 +242,15 @@ describe('ProjectForm component', () => {
 
         // ASSERT
         expect(vm.participants).to.deep.equal([
-          { specialRequirementsProvided: false },
-          { specialRequirementsProvided: false },
-          { specialRequirementsProvided: false },
+          {
+            firstName: '', lastName: '', specialRequirements: '', specialRequirementsProvided: false,
+          },
+          {
+            firstName: '', lastName: '', specialRequirements: '', specialRequirementsProvided: false,
+          },
+          {
+            firstName: '', lastName: '', specialRequirements: '', specialRequirementsProvided: false,
+          },
         ]);
       });
 


### PR DESCRIPTION
On Android devices it won't let you input anything in text boxes unless
the property that box is bound to is initialized with a value.