### PR TITLE
Add a required configuration line for seating

### DIFF
--- a/server/database/migrations/17.add-event-categories-ages.js
+++ b/server/database/migrations/17.add-event-categories-ages.js
@@ -1,0 +1,9 @@
+exports.up = (knex, Promise) =>
+  knex.schema.table('event', (table) => {
+    table.jsonb('categories_ages').comment('Object of array of ages per category');
+  });
+
+exports.down = (knex, Promise) =>
+  knex.schema.table('event', (table) => {
+    table.dropColumn('categories_ages');
+  });

--- a/server/database/seeds/01.event.js
+++ b/server/database/seeds/01.event.js
@@ -16,6 +16,7 @@ exports.seed = (knex, Promise) =>
       homepage: 'coolestprojects.org',
       slug: 'cp-2018',
       categories: { SC: 'Scratch', WEB: 'Websites & Web Games', EVO: 'Evolution' },
+      categories_ages: { SC: [11], WEB: [10, 12], EVO: [] },
       registration_start: eventDate.clone().subtract(3, 'days'),
       registration_end: eventDate.clone().subtract(1, 'days'),
       freeze_date: eventDate.clone().subtract(1, 'days').toDate(),

--- a/server/models/category.js
+++ b/server/models/category.js
@@ -1,0 +1,33 @@
+module.exports = class Category {
+  constructor(name, ageSplit) {
+    this.name = name;
+    this.ages = ageSplit ? ageSplit.sort((a, b) => a - b) : [];
+  }
+  // eslint-disable-next-line class-methods-use-this 
+  lowBoundFilter(age) {
+    return ['age', '<', age];
+  }
+  // eslint-disable-next-line class-methods-use-this 
+  highBoundFilter(age) {
+    return ['age', '>', age];
+  }
+  get filters() {
+    let filters = [null];
+    // Return an array of categories +1, as the age defines a split and we want whatever's after
+    if (this.ages.length > 0) {
+      const lastAge = this.ages[this.ages.length - 1];
+      filters = this.ages
+        .reduce((acc, age) => {
+          if (acc.length > 0) {
+            const prevAge = this.ages[acc.length - 1];
+            acc.push([this.lowBoundFilter(age), this.highBoundFilter(prevAge)]);
+          } else {
+            acc.push(this.lowBoundFilter(age));
+          }
+          return acc;
+        }, []);
+      filters.push(this.highBoundFilter(lastAge));
+    }
+    return filters;
+  }
+};

--- a/server/models/category.js
+++ b/server/models/category.js
@@ -5,7 +5,7 @@ module.exports = class Category {
   }
   // eslint-disable-next-line class-methods-use-this 
   lowBoundFilter(age) {
-    return ['age', '<', age];
+    return ['age', '<=', age];
   }
   // eslint-disable-next-line class-methods-use-this 
   highBoundFilter(age) {

--- a/server/routes/handlers/events.js
+++ b/server/routes/handlers/events.js
@@ -1,5 +1,6 @@
 const eventController = require('../../controllers/events');
 const projectController = require('../../controllers/projects');
+const Category = require('../../models/category');
 
 module.exports = {
   get: [
@@ -64,13 +65,12 @@ module.exports = {
       return next();
     },
     (req, res, next) => {
-      let categories = res.app.locals.event.attributes.categories;
-      // Technically, the following line is useless on pg, but required for tests (sqlite)
-      if (typeof categories === 'string') {
-        categories = JSON.parse(categories);
-      }
+      const categories = res.app.locals.event.attributes.categories;
+      const categoriesAges = res.app.locals.event.attributes.categoriesAges;
       return Promise.all(Object.keys(categories)
-        .map(cat => projectController.setSeatingPerCategory(cat)))
+        .map(catName => projectController.setSeatingPerCategory(
+          new Category(catName, categoriesAges[catName]),
+        )))
         .then(() => next())
         .catch((err) => {
           req.app.locals.logger.error(err);

--- a/server/test/unit/controllers/projects.setSeating.spec.js
+++ b/server/test/unit/controllers/projects.setSeating.spec.js
@@ -44,13 +44,13 @@ describe('projects controllers: setSeatingPerCategory', () => {
   });
   it('should assign seats with a single filter', async () => {
     projectModel.fetchAll.resolves({ models: new Array(10).fill({ attributes: { id: 1 } }) });
-    await controllers.setSeating('BANANA', ['age', '<', 10], 10, '');
+    await controllers.setSeating('BANANA', ['age', '<=', 10], 10, '');
     expect(projectModel.ageGroup).to.have.been.calledOnce;
     expect(projectModel.where).to.have.been.callCount(4);
     expect(projectModel.where.getCall(0)).to.have.been.calledWith('deleted_at', null);
     expect(projectModel.where.getCall(1)).to.have.been.calledWith('status', '!=', 'canceled');
     expect(projectModel.where.getCall(2)).to.have.been.calledWith('category', 'BANANA');
-    expect(projectModel.where.getCall(3)).to.have.been.calledWith('age', '<', 10);
+    expect(projectModel.where.getCall(3)).to.have.been.calledWith('age', '<=', 10);
     expect(projectModel.orderBy).to.have.been.calledOnce;
     expect(projectModel.orderBy).to.have.been.calledWith('org_ref', 'DESC');
     expect(projectModel.fetchAll).to.have.been.calledOnce;
@@ -62,13 +62,13 @@ describe('projects controllers: setSeatingPerCategory', () => {
   });
   it('should assign seats with multiple filters', async () => {
     projectModel.fetchAll.resolves({ models: new Array(10).fill({ attributes: { id: 1 } }) });
-    await controllers.setSeating('BANANA', [['age', '<', 10], ['age', '>', 8]], 10, '');
+    await controllers.setSeating('BANANA', [['age', '<=', 10], ['age', '>', 8]], 10, '');
     expect(projectModel.ageGroup).to.have.been.calledOnce;
     expect(projectModel.where).to.have.been.callCount(5);
     expect(projectModel.where.getCall(0)).to.have.been.calledWith('deleted_at', null);
     expect(projectModel.where.getCall(1)).to.have.been.calledWith('status', '!=', 'canceled');
     expect(projectModel.where.getCall(2)).to.have.been.calledWith('category', 'BANANA');
-    expect(projectModel.where.getCall(3)).to.have.been.calledWith('age', '<', 10);
+    expect(projectModel.where.getCall(3)).to.have.been.calledWith('age', '<=', 10);
     expect(projectModel.where.getCall(4)).to.have.been.calledWith('age', '>', 8);
     expect(projectModel.orderBy).to.have.been.calledOnce;
     expect(projectModel.orderBy).to.have.been.calledWith('org_ref', 'DESC');

--- a/server/test/unit/controllers/projects.setSeating.spec.js
+++ b/server/test/unit/controllers/projects.setSeating.spec.js
@@ -30,7 +30,7 @@ describe('projects controllers: setSeatingPerCategory', () => {
   });
   it('should assign seats without filter', async () => {
     projectModel.fetchAll.resolves({ models: new Array(10).fill({ attributes: { id: 1 } }) });
-    await controllers.setSeating('BANANA', null, 10);
+    await controllers.setSeating('BANANA', null, 10, '');
     expect(projectModel.ageGroup).to.have.been.calledOnce;
     expect(projectModel.where).to.have.been.calledThrice;
     expect(projectModel.where.getCall(0)).to.have.been.calledWith('deleted_at', null);
@@ -42,15 +42,34 @@ describe('projects controllers: setSeatingPerCategory', () => {
     expect(projectModel.fetchAll).to.have.been.calledWith({ withRelated: ['seat'] });
     expect(seatModel.save).to.have.been.callCount(10);
   });
-  it('should assign seats with filter', async () => {
+  it('should assign seats with a single filter', async () => {
     projectModel.fetchAll.resolves({ models: new Array(10).fill({ attributes: { id: 1 } }) });
-    await controllers.setSeating('BANANA', ['age', '<', 10], 10);
+    await controllers.setSeating('BANANA', ['age', '<', 10], 10, '');
     expect(projectModel.ageGroup).to.have.been.calledOnce;
     expect(projectModel.where).to.have.been.callCount(4);
     expect(projectModel.where.getCall(0)).to.have.been.calledWith('deleted_at', null);
     expect(projectModel.where.getCall(1)).to.have.been.calledWith('status', '!=', 'canceled');
     expect(projectModel.where.getCall(2)).to.have.been.calledWith('category', 'BANANA');
     expect(projectModel.where.getCall(3)).to.have.been.calledWith('age', '<', 10);
+    expect(projectModel.orderBy).to.have.been.calledOnce;
+    expect(projectModel.orderBy).to.have.been.calledWith('org_ref', 'DESC');
+    expect(projectModel.fetchAll).to.have.been.calledOnce;
+    expect(projectModel.fetchAll).to.have.been.calledWith({ withRelated: ['seat'] });
+    expect(seatModelConstructor).to.have.been.callCount(10);
+    expect(seatModelConstructor.getCall(0)).to.have.been.calledWith({ project_id: 1, seat: 'BANANA-10' });
+    expect(seatModelConstructor.getCall(9)).to.have.been.calledWith({ project_id: 1, seat: 'BANANA-19' });
+    expect(seatModel.save).to.have.been.callCount(10);
+  });
+  it('should assign seats with multiple filters', async () => {
+    projectModel.fetchAll.resolves({ models: new Array(10).fill({ attributes: { id: 1 } }) });
+    await controllers.setSeating('BANANA', [['age', '<', 10], ['age', '>', 8]], 10, '');
+    expect(projectModel.ageGroup).to.have.been.calledOnce;
+    expect(projectModel.where).to.have.been.callCount(5);
+    expect(projectModel.where.getCall(0)).to.have.been.calledWith('deleted_at', null);
+    expect(projectModel.where.getCall(1)).to.have.been.calledWith('status', '!=', 'canceled');
+    expect(projectModel.where.getCall(2)).to.have.been.calledWith('category', 'BANANA');
+    expect(projectModel.where.getCall(3)).to.have.been.calledWith('age', '<', 10);
+    expect(projectModel.where.getCall(4)).to.have.been.calledWith('age', '>', 8);
     expect(projectModel.orderBy).to.have.been.calledOnce;
     expect(projectModel.orderBy).to.have.been.calledWith('org_ref', 'DESC');
     expect(projectModel.fetchAll).to.have.been.calledOnce;

--- a/server/test/unit/controllers/projects.setSeatingPerCategory.spec.js
+++ b/server/test/unit/controllers/projects.setSeatingPerCategory.spec.js
@@ -1,4 +1,5 @@
 const proxy = require('proxyquire').noCallThru();
+const Category = require('../../../models/category');
 
 describe('projects controllers: setSeatingPerCategory', () => {
   let controllers;
@@ -13,19 +14,23 @@ describe('projects controllers: setSeatingPerCategory', () => {
   afterEach(() => {
     sandbox.restore();
   });
-  it('should call setSeating if the category is not SC', async () => {
-    controllers.setSeating = sandbox.stub();
-    await controllers.setSeatingPerCategory('BANANA');
+  it('should call setSeating if the category is split', async () => {
+    controllers.setSeating = sandbox.stub().resolves(new Array(10).fill(1));
+    const cat = new Category('HW');
+    await controllers.setSeatingPerCategory(cat);
     expect(controllers.setSeating).to.have.been.calledOnce;
-    expect(controllers.setSeating).to.have.been.calledWith('BANANA', null, 100);
+    expect(controllers.setSeating).to.have.been.calledWith('HW', null, 100, '');
   });
 
-  it('shoud do the age split if the category is SC', async () => {
+  it('shoud call setSeating multiple time if there is an age split', async () => {
     const sizeSeed = Math.ceil(Math.random() * 100);
     controllers.setSeating = sandbox.stub().resolves(new Array(sizeSeed).fill(sizeSeed));
-    await controllers.setSeatingPerCategory('SC');
-    expect(controllers.setSeating).to.have.been.calledTwice;
-    expect(controllers.setSeating.getCall(0)).to.have.been.calledWith('SC', ['age', '<=', 11], 100);
-    expect(controllers.setSeating.getCall(1)).to.have.been.calledWith('SC', ['age', '>', 11], 100 + sizeSeed);
+    const cat = new Category('HW', [12, 14, 3]);
+    await controllers.setSeatingPerCategory(cat);
+    expect(controllers.setSeating).to.have.callCount(4);
+    expect(controllers.setSeating.getCall(0)).to.have.been.calledWith('HW', ['age', '<', 3], 100, 1);
+    expect(controllers.setSeating.getCall(1)).to.have.been.calledWith('HW', [['age', '<', 12], ['age', '>', 3]], 100 + (sizeSeed), 2);
+    expect(controllers.setSeating.getCall(2)).to.have.been.calledWith('HW', [['age', '<', 14], ['age', '>', 12]], 100 + (sizeSeed * 2), 3);
+    expect(controllers.setSeating.getCall(3)).to.have.been.calledWith('HW', ['age', '>', 14], 100 + (sizeSeed * 3), 4);
   });
 });

--- a/server/test/unit/controllers/projects.setSeatingPerCategory.spec.js
+++ b/server/test/unit/controllers/projects.setSeatingPerCategory.spec.js
@@ -28,9 +28,9 @@ describe('projects controllers: setSeatingPerCategory', () => {
     const cat = new Category('HW', [12, 14, 3]);
     await controllers.setSeatingPerCategory(cat);
     expect(controllers.setSeating).to.have.callCount(4);
-    expect(controllers.setSeating.getCall(0)).to.have.been.calledWith('HW', ['age', '<', 3], 100, 1);
-    expect(controllers.setSeating.getCall(1)).to.have.been.calledWith('HW', [['age', '<', 12], ['age', '>', 3]], 100 + (sizeSeed), 2);
-    expect(controllers.setSeating.getCall(2)).to.have.been.calledWith('HW', [['age', '<', 14], ['age', '>', 12]], 100 + (sizeSeed * 2), 3);
+    expect(controllers.setSeating.getCall(0)).to.have.been.calledWith('HW', ['age', '<=', 3], 100, 1);
+    expect(controllers.setSeating.getCall(1)).to.have.been.calledWith('HW', [['age', '<=', 12], ['age', '>', 3]], 100 + (sizeSeed), 2);
+    expect(controllers.setSeating.getCall(2)).to.have.been.calledWith('HW', [['age', '<=', 14], ['age', '>', 12]], 100 + (sizeSeed * 2), 3);
     expect(controllers.setSeating.getCall(3)).to.have.been.calledWith('HW', ['age', '>', 14], 100 + (sizeSeed * 3), 4);
   });
 });

--- a/server/test/unit/models/category.spec.js
+++ b/server/test/unit/models/category.spec.js
@@ -15,11 +15,11 @@ describe('Category', () => {
     });
     it('should return the filter when there is a single age split', () => {
       const cat = new Category('HW', [2]);
-      expect(cat.filters).to.eql([['age', '<', 2], ['age', '>', 2]]);
+      expect(cat.filters).to.eql([['age', '<=', 2], ['age', '>', 2]]);
     });
     it('should return the filter when there is multiple age split', () => {
       const cat = new Category('HW', [4, 2]);
-      expect(cat.filters).to.eql([['age', '<', 2], [['age', '<', 4], ['age', '>', 2]], ['age', '>', 4]]);
+      expect(cat.filters).to.eql([['age', '<=', 2], [['age', '<=', 4], ['age', '>', 2]], ['age', '>', 4]]);
     });
   });
 });

--- a/server/test/unit/models/category.spec.js
+++ b/server/test/unit/models/category.spec.js
@@ -1,0 +1,25 @@
+const Category = require('../../../models/category');
+
+describe('Category', () => {
+  describe('constructor', () => {
+    it('should create a Category with its attr', () => {
+      const cat = new Category('HW', [10]);
+      expect(cat.name).to.equal('HW');
+      expect(cat.ages).to.eql([10]);
+    });
+  });
+  describe('filters', () => {
+    it('should return the filter when there is no age split', () => {
+      const cat = new Category('HW');
+      expect(cat.filters).to.eql([null]);
+    });
+    it('should return the filter when there is a single age split', () => {
+      const cat = new Category('HW', [2]);
+      expect(cat.filters).to.eql([['age', '<', 2], ['age', '>', 2]]);
+    });
+    it('should return the filter when there is multiple age split', () => {
+      const cat = new Category('HW', [4, 2]);
+      expect(cat.filters).to.eql([['age', '<', 2], [['age', '<', 4], ['age', '>', 2]], ['age', '>', 4]]);
+    });
+  });
+});

--- a/server/test/unit/routes/events.postSeating.spec.js
+++ b/server/test/unit/routes/events.postSeating.spec.js
@@ -36,7 +36,15 @@ describe('router: event', () => {
     });
     it('should set the seating for each categories', async () => {
       const refresh = sandbox.stub();
-      const event = { attributes: { id: 1, seatingPrepared: false, categories: { SC: 'scratch' } }, refresh };
+      const event = {
+        attributes: {
+          id: 1,
+          seatingPrepared: false,
+          categories: { SC: 'scratch' },
+          categoriesAges: { SC: [] },
+        },
+        refresh,
+      };
       const req = { params: { eventId: 1 } };
       const res = {
         app: { locals: {} },
@@ -53,7 +61,7 @@ describe('router: event', () => {
 
       expect(eventController.get).to.have.calledOnce;
       expect(projectController.setSeatingPerCategory).to.have.calledOnce;
-      expect(projectController.setSeatingPerCategory).to.have.calledWith('SC');
+      expect(projectController.setSeatingPerCategory).to.have.calledWith({ ages: [], name: 'SC' });
       expect(eventController.update).to.have.calledOnce;
       expect(eventController.update).to.have.calledWith(event, { seatingPrepared: true });
       expect(event.refresh).to.have.been.calledOnce;
@@ -62,7 +70,14 @@ describe('router: event', () => {
       expect(next).to.have.been.callCount(4);
     });
     it('should not set the seating when it\'s already set', async () => {
-      const event = { attributes: { id: 1, seatingPrepared: true, categories: { SC: 'scratch' } } };
+      const event = {
+        attributes: {
+          id: 1,
+          seatingPrepared: true,
+          categories: { SC: 'scratch' },
+          categoriesAges: { SC: [] },
+        },
+      };
       const req = { params: { eventId: 1 } };
       const res = {
         app: { locals: {} },
@@ -115,7 +130,14 @@ describe('router: event', () => {
       const logger = {
         error: sandbox.stub(),
       };
-      const event = { attributes: { id: 1, seatingPrepared: false, categories: { SC: 'scratch' } } };
+      const event = {
+        attributes: {
+          id: 1,
+          seatingPrepared: false,
+          categories: { SC: 'scratch' },
+          categoriesAges: { SC: [] },
+        },
+      };
       const req = { params: { eventId: 1 }, app: { locals: { logger } } };
       const res = {
         app: { locals: {} },
@@ -139,7 +161,15 @@ describe('router: event', () => {
     });
     it('should throw if saving the event failed', async () => {
       const refresh = sandbox.stub();
-      const event = { attributes: { id: 1, seatingPrepared: false, categories: { SC: 'scratch' } }, refresh };
+      const event = {
+        attributes: {
+          id: 1,
+          seatingPrepared: false,
+          categories: { SC: 'scratch' },
+          categoriesAges: { SC: [] },
+        },
+        refresh,
+      };
       const req = { params: { eventId: 1 } };
       const res = {
         app: { locals: {} },
@@ -156,7 +186,7 @@ describe('router: event', () => {
 
       expect(eventController.get).to.have.calledOnce;
       expect(projectController.setSeatingPerCategory).to.have.calledOnce;
-      expect(projectController.setSeatingPerCategory).to.have.calledWith('SC');
+      expect(projectController.setSeatingPerCategory).to.have.calledWith({ ages: [], name: 'SC' });
       expect(eventController.update).to.have.calledOnce;
       expect(eventController.update).to.have.calledWith(event, { seatingPrepared: true });
       expect(event.refresh).to.have.been.calledOnce;


### PR DESCRIPTION
Allow to split the categories per ages
Solves https://github.com/CoderDojo/coolest-platform/issues/200
Requires the configuration to be set on production in order for it to work. 